### PR TITLE
Refactor: Unify config_server.py into fenetre.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the local files into the container
 COPY fenetre.py timelapse.py daylight.py archive.py index.html /app/
+COPY config_server.py /app/
 
 # Add the lib directoy to /app
 COPY lib /app/lib
+
+# Add the static directory for the config server UI to /app/static
+COPY static /app/static/
 
 # Set entrypoint to allow dynamic config.yaml file specification
 ENTRYPOINT ["python", "fenetre.py", "--config"]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,10 @@ http_server:
   port: 8888
   host: 0.0.0.0
   enabled: True
+config_server:
+  enabled: true       # Enable the web UI for configuration
+  host: "0.0.0.0"     # Host for the config server
+  port: 8889          # Port for the config server
 cameras:
   a-cool-http-cam-with-clouds:
     url: "https://isitfoggy.com/photos/latest.jpg"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ open-gopro
 bleak
 Flask
 PyYAML
+waitress


### PR DESCRIPTION
I've integrated the Flask-based configuration server directly into the main fenetre.py application. This unification simplifies deployment and process management by running a single main Python process.

Key changes:
- I modified `fenetre.py` to launch the Flask app (from `config_server.py`) in a separate thread, managed by `fenetre.py`'s configuration and lifecycle (start, stop, reload via SIGHUP).
- I added a new `config_server` section to the main YAML configuration file (`config.yaml`) to control the embedded Flask server (enable, host, port).
- I adapted `config_server.py` to be importable:
    - Removed standalone execution.
    - Routes now fetch necessary configurations (e.g., main config file path, PID file path) from `app.config`, which is populated by `fenetre.py`.
- I updated `config.example.yaml` with the new `config_server` section.
- I added `waitress` to `requirements.txt` as the preferred WSGI server for the Flask app.
- I updated `Dockerfile` to include `config_server.py` and its `static` UI assets in the image, and to ensure `waitress` is installed.