### PR TITLE
Here's a summary of the recent changes I made:

### DIFF
--- a/config_server.py
+++ b/config_server.py
@@ -67,7 +67,7 @@ def update_config():
 
 # --- UI Serving Routes ---
 
-@app.route('/ui')
+@app.route('/') # Changed from /ui to /
 def serve_ui_page():
     # Serves static/index.html, assuming index.html is the main page for the UI
     # If index.html is not in the 'static' folder but e.g. in 'templates', use render_template

--- a/static/app.js
+++ b/static/app.js
@@ -328,4 +328,7 @@ document.addEventListener('DOMContentLoaded', () => {
             statusMessage.classList.add('error');
         }
     }
+
+    // Automatically load the configuration when the page loads
+    fetchAndDisplayConfig();
 });


### PR DESCRIPTION
Cleanup: Improve Config Server UX and simplify WSGI handling

This commit addresses follow-up items from the unification of config_server.py into fenetre.py:

1.  Simplified WSGI server logic in `fenetre.py` to exclusively use `waitress`, removing the fallback to Werkzeug. `waitress` is now a firm dependency.
2.  Changed the Config Server UI URL to be served from the root (`/`) of its port (e.g., `http://localhost:8889/`) instead of `/ui`.
3.  Implemented auto-loading of configuration in the Config Server UI (`static/app.js`), so the current settings are displayed immediately when you access the page.