### PR TITLE
colorize header only in logs

### DIFF
--- a/src/fenetre/logging_utils.py
+++ b/src/fenetre/logging_utils.py
@@ -1,0 +1,22 @@
+import logging
+
+
+class ModuleColorFormatter(logging.Formatter):
+    COLORS = {
+        logging.DEBUG: "\x1b[37m",
+        logging.INFO: "\x1b[36m",
+        logging.WARNING: "\x1b[33m",
+        logging.ERROR: "\x1b[31m",
+        logging.CRITICAL: "\x1b[35m",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+        color = self.COLORS.get(record.levelno)
+        if not color:
+            return base
+        if "]" not in base:
+            return f"{color}{base}\x1b[0m"
+        header, message = base.split("]", 1)
+        header += "]"
+        return f"{color}{header}\x1b[0m{message}"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,12 @@
+import logging
+
+from fenetre.logging_utils import ModuleColorFormatter
+
+def test_header_has_color_only():
+    formatter = ModuleColorFormatter("[%(levelname)s] %(message)s")
+    record = logging.LogRecord("mod", logging.INFO, "", 0, "msg", (), None)
+    formatted = formatter.format(record)
+    color = ModuleColorFormatter.COLORS[logging.INFO]
+    header, message = formatted.split("\x1b[0m", 1)
+    assert header == f"{color}[INFO]"
+    assert "\x1b[" not in message


### PR DESCRIPTION
## Summary
- color only log header in ModuleColorFormatter
- add test ensuring message remains uncolored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa9dc8f440832cbdd2830e7b943fd2