### PR TITLE
Add deterministic local-command landscape integration test fixtures

### DIFF
--- a/itests/config.integration.local_command.yaml
+++ b/itests/config.integration.local_command.yaml
@@ -1,0 +1,22 @@
+global:
+  timezone: UTC
+  work_dir: __WORK_DIR__
+
+http_server:
+  enabled: false
+
+admin_server:
+  enabled: false
+
+timelapse:
+  enabled: false
+
+cameras:
+  fake_landscape:
+    local_command: __LOCAL_COMMAND__
+    timeout_s: 10
+    snap_interval_s: 3600
+    gather_metrics: false
+    ssim_setpoint: 0.85
+    lat: 48.8566
+    lon: 2.3522

--- a/itests/generate_landscape.py
+++ b/itests/generate_landscape.py
@@ -1,0 +1,149 @@
+import argparse
+import datetime as dt
+from io import BytesIO
+import sys
+
+from astral import Observer, moon
+from astral.sun import azimuth as sun_azimuth
+from astral.sun import elevation as sun_elevation
+from PIL import Image, ImageDraw
+
+
+def _parse_time(time_file: str) -> dt.datetime:
+    with open(time_file, "r", encoding="utf-8") as f:
+        raw = f.read().strip()
+    parsed = dt.datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return parsed
+
+
+def _angle_delta_degrees(target: float, camera_azimuth: float) -> float:
+    return (target - camera_azimuth + 180.0) % 360.0 - 180.0
+
+
+def _project_to_image(
+    obj_azimuth: float,
+    obj_elevation: float,
+    camera_azimuth: float,
+    fov: float,
+    width: int,
+    height: int,
+):
+    az_delta = _angle_delta_degrees(obj_azimuth, camera_azimuth)
+    if abs(az_delta) > (fov / 2.0):
+        return None
+
+    x = int(round(((az_delta / fov) + 0.5) * (width - 1)))
+    horizon_y = (height // 2) - 1
+    y = int(round(horizon_y - (obj_elevation / 90.0) * horizon_y))
+    y = max(0, min(height - 1, y))
+    return x, y
+
+
+def _blend(c1, c2, t: float):
+    clamped_t = max(0.0, min(1.0, t))
+    return tuple(int(round(a + (b - a) * clamped_t)) for a, b in zip(c1, c2))
+
+
+def _scene_palette(sun_elev: float):
+    day_sky = (70, 160, 255)
+    twilight_sky = (255, 140, 170)
+    night_sky = (18, 24, 52)
+    day_ground = (60, 160, 70)
+    night_ground = (20, 55, 28)
+
+    if sun_elev >= 6.0:
+        return day_sky, day_ground
+    if sun_elev <= -6.0:
+        return night_sky, night_ground
+
+    twilight_mix = 1.0 - min(abs(sun_elev) / 6.0, 1.0)
+    if sun_elev >= 0:
+        sky = _blend(day_sky, twilight_sky, twilight_mix)
+    else:
+        sky = _blend(night_sky, twilight_sky, twilight_mix)
+
+    day_mix = max(0.0, min((sun_elev + 6.0) / 12.0, 1.0))
+    ground = _blend(night_ground, day_ground, day_mix)
+    return sky, ground
+
+
+def generate_image(
+    width: int,
+    height: int,
+    latitude: float,
+    longitude: float,
+    camera_azimuth: float,
+    fov: float,
+    when: dt.datetime,
+) -> Image.Image:
+    observer = Observer(latitude=latitude, longitude=longitude)
+    sun_el = sun_elevation(observer, when)
+    sun_az = sun_azimuth(observer, when)
+    moon_el = moon.elevation(observer, when)
+    moon_az = moon.azimuth(observer, when)
+
+    sky_color, ground_color = _scene_palette(sun_el)
+
+    image = Image.new("RGB", (width, height), sky_color)
+    draw = ImageDraw.Draw(image)
+    horizon_y = height // 2
+    draw.rectangle((0, horizon_y, width, height), fill=ground_color)
+
+    sun_xy = _project_to_image(sun_az, sun_el, camera_azimuth, fov, width, height)
+    if sun_xy is not None and sun_el > -2.0:
+        draw.ellipse(
+            (
+                sun_xy[0] - 8,
+                sun_xy[1] - 8,
+                sun_xy[0] + 8,
+                sun_xy[1] + 8,
+            ),
+            fill=(255, 235, 120),
+        )
+
+    moon_xy = _project_to_image(moon_az, moon_el, camera_azimuth, fov, width, height)
+    if moon_xy is not None and moon_el > -2.0:
+        draw.ellipse(
+            (
+                moon_xy[0] - 6,
+                moon_xy[1] - 6,
+                moon_xy[0] + 6,
+                moon_xy[1] + 6,
+            ),
+            fill=(220, 220, 235),
+        )
+
+    return image
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--width", type=int, default=320)
+    parser.add_argument("--height", type=int, default=180)
+    parser.add_argument("--lat", type=float, required=True)
+    parser.add_argument("--lon", type=float, required=True)
+    parser.add_argument("--camera-azimuth", type=float, default=80.0)
+    parser.add_argument("--fov", type=float, default=120.0)
+    parser.add_argument("--time-file", type=str, required=True)
+    args = parser.parse_args()
+
+    when = _parse_time(args.time_file)
+    image = generate_image(
+        width=args.width,
+        height=args.height,
+        latitude=args.lat,
+        longitude=args.lon,
+        camera_azimuth=args.camera_azimuth,
+        fov=args.fov,
+        when=when,
+    )
+
+    out = BytesIO()
+    image.save(out, format="JPEG", quality=92)
+    sys.stdout.buffer.write(out.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/itests/integration_test_spec.md
+++ b/itests/integration_test_spec.md
@@ -1,0 +1,51 @@
+# Integration test plan: deterministic local-command landscape camera
+
+## Scope
+- Add a deterministic image generator used as a `local_command` camera source.
+- Add an integration test that runs a virtualized 25-hour capture timeline (including day transition and month transition) without waiting in real time.
+- Keep all generated runtime artifacts in temporary directories rooted under `itests/`.
+
+## Why this approach
+- Running the full app clock for 25 hours in real time is not practical.
+- `snap()` already encapsulates the capture loop and file output path logic, so using it with controlled time gives broad integration coverage while staying fast.
+- A subprocess-driven generator validates the `local_command` execution path end-to-end.
+
+## Deterministic landscape generator specs
+- Output is a JPEG image (default 320x180, configurable).
+- Bottom half: green ground.
+- Top half: sky color based on sun elevation:
+  - day: blue,
+  - twilight (around sunrise/sunset): pink blending,
+  - night: darker sky.
+- Sun and moon positions are derived from:
+  - GPS coordinates (lat/lon),
+  - timestamp,
+  - camera azimuth (`80°`),
+  - field of view (`120°`).
+- Object visibility uses their azimuth/elevation and projects them into image coordinates.
+- Determinism:
+  - no randomness,
+  - same input args + timestamp => byte-identical output in practice for the same Pillow runtime.
+
+## Integration test specs
+- Use a dedicated config template in `itests/config.integration.local_command.yaml` with one camera using `local_command`.
+- Runtime setup:
+  - create temp root with `tempfile.TemporaryDirectory(dir=itests_dir)`.
+  - place `work_dir`, mock-time file, and concrete config there.
+- Time virtualization:
+  - patch `fenetre.datetime.now()` reads from a mutable virtual clock,
+  - patch `fenetre.interruptible_sleep()` to advance the virtual clock instantly,
+  - update the generator time-file after each virtual sleep.
+- Capture span:
+  - start at `2024-01-31T00:00:00Z`,
+  - run hourly for 25 hours (26 written frames: 00:00 through next day 01:00),
+  - this guarantees day and month transitions.
+- Assertions:
+  - expected day directories exist (`2024-01-31`, `2024-02-01`),
+  - expected frame counts per day (24 and 2),
+  - generated noon frame has higher brightness than midnight frame,
+  - thread exits cleanly.
+
+## Constraints / tradeoffs
+- This validates the snap loop + local command + file layout, not the full process-level thread orchestration from `load_and_apply_configuration()`.
+- The generator is intentionally simple to keep CPU usage low for Raspberry Pi-class environments.

--- a/itests/test_local_command_landscape_integration.py
+++ b/itests/test_local_command_landscape_integration.py
@@ -1,0 +1,140 @@
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytz
+from PIL import Image, ImageStat
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.fenetre.config import config_load
+from src.fenetre.fenetre import exit_event, shutdown_application
+from src.fenetre import fenetre as fenetre_module
+
+
+class _FrozenDateTime(datetime):
+    current = datetime(2024, 1, 31, 0, 0, tzinfo=pytz.UTC)
+
+    @classmethod
+    def now(cls, tz=None):
+        value = cls.current
+        if tz is None:
+            return value.replace(tzinfo=None)
+        return value.astimezone(tz)
+
+
+class LocalCommandLandscapeIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for collector in collectors:
+            REGISTRY.unregister(collector)
+
+        itests_dir = Path(__file__).resolve().parent
+        self.temp_dir = tempfile.TemporaryDirectory(dir=itests_dir)
+        self.runtime_dir = Path(self.temp_dir.name)
+        self.work_dir = self.runtime_dir / "work"
+        self.time_file = self.runtime_dir / "virtual_time.txt"
+        self.config_path = self.runtime_dir / "config.yaml"
+        _FrozenDateTime.current = datetime(2024, 1, 31, 0, 0, tzinfo=pytz.UTC)
+        self.time_file.write_text(_FrozenDateTime.current.isoformat(), encoding="utf-8")
+
+        script_path = Path(__file__).resolve().parent / "generate_landscape.py"
+        python_path = Path(__file__).resolve().parent.parent / "venv" / "bin" / "python"
+        local_command = (
+            f"{python_path} {script_path} --width 320 --height 180 --lat 48.8566 --lon 2.3522 "
+            f"--camera-azimuth 80 --fov 120 --time-file {self.time_file}"
+        )
+
+        template_path = (
+            Path(__file__).resolve().parent / "config.integration.local_command.yaml"
+        )
+        template = template_path.read_text(encoding="utf-8")
+        config_content = template.replace("__WORK_DIR__", str(self.work_dir)).replace(
+            "__LOCAL_COMMAND__", local_command
+        )
+        self.config_path.write_text(config_content, encoding="utf-8")
+
+        fenetre_module.server_config = {}
+        fenetre_module.cameras_config = {}
+        fenetre_module.global_config = {}
+        fenetre_module.sleep_intervals = {}
+        fenetre_module.active_camera_threads = {}
+        fenetre_module.daylight_q = []
+        fenetre_module.exit_event.clear()
+
+    def tearDown(self):
+        shutdown_application()
+        self.temp_dir.cleanup()
+
+    def test_25_hour_capture_crosses_day_and_month(self):
+        _, cameras_config, global_config, _, _ = config_load(str(self.config_path))
+        fenetre_module.global_config = global_config
+
+        camera_name = "fake_landscape"
+        camera_config = cameras_config[camera_name]
+
+        expected_frame_count = 26
+        written_frames = {"count": 0}
+        original_write = fenetre_module.write_pic_to_disk
+
+        def counting_write(pic, pic_path, optimize=False, exif_data=b""):
+            original_write(pic, pic_path, optimize, exif_data)
+            written_frames["count"] += 1
+            if written_frames["count"] >= expected_frame_count:
+                fenetre_module.exit_event.set()
+
+        def fast_sleep(duration, should_exit):
+            if should_exit.is_set():
+                return
+            _FrozenDateTime.current += timedelta(seconds=duration)
+            self.time_file.write_text(
+                _FrozenDateTime.current.isoformat(), encoding="utf-8"
+            )
+
+        with (
+            mock.patch.object(fenetre_module, "datetime", _FrozenDateTime),
+            mock.patch.object(
+                fenetre_module, "interruptible_sleep", side_effect=fast_sleep
+            ),
+            mock.patch.object(
+                fenetre_module, "write_pic_to_disk", side_effect=counting_write
+            ),
+        ):
+            snap_thread = threading.Thread(
+                target=fenetre_module.snap,
+                args=[camera_name, camera_config],
+                daemon=True,
+            )
+            snap_thread.start()
+            snap_thread.join(timeout=15)
+
+        self.assertFalse(snap_thread.is_alive())
+
+        jan_dir = self.work_dir / "photos" / camera_name / "2024-01-31"
+        feb_dir = self.work_dir / "photos" / camera_name / "2024-02-01"
+        self.assertTrue(jan_dir.exists())
+        self.assertTrue(feb_dir.exists())
+
+        jan_frames = sorted(jan_dir.glob("*.jpg"))
+        feb_frames = sorted(feb_dir.glob("*.jpg"))
+        self.assertEqual(len(jan_frames), 24)
+        self.assertEqual(len(feb_frames), 2)
+
+        noon = jan_dir / "2024-01-31T12-00-00UTC.jpg"
+        midnight = jan_dir / "2024-01-31T00-00-00UTC.jpg"
+        self.assertTrue(noon.exists())
+        self.assertTrue(midnight.exists())
+
+        noon_brightness = ImageStat.Stat(Image.open(noon).convert("L")).mean[0]
+        midnight_brightness = ImageStat.Stat(Image.open(midnight).convert("L")).mean[0]
+        self.assertGreater(noon_brightness, midnight_brightness)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a deterministic, fast alternative to a real camera to enable reliable integration tests that exercise the `local_command` capture path. 
- Validate a full 25-hour capture window (day → next day) including a month rollover so the daylight/archiving code paths are exercised. 
- Keep runtime artifacts scoped to temporary directories under `itests/` so the tests remain isolated and low-cost for small devices.

### Description

- Add a simple deterministic image generator `itests/generate_landscape.py` that renders a blue/green landscape, applies day/twilight/night palettes, and projects sun/moon positions from GPS + timestamp using azimuth/FOV parameters. 
- Add an integration config template `itests/config.integration.local_command.yaml` that uses `local_command` and placeholders (`__WORK_DIR__`, `__LOCAL_COMMAND__`) for runtime substitution. 
- Add `itests/test_local_command_landscape_integration.py` which virtualizes time by patching `fenetre.datetime.now` and `fenetre.interruptible_sleep`, drives `snap()` against the generator for a 25-hour simulated timeline, and asserts directory rollover and brightness expectations. 
- Add a human-facing spec `itests/integration_test_spec.md` describing the generator, virtual-time strategy and test assertions for future reference.

### Testing

- Formatted tests with `venv/bin/black` (reformatted `itests/test_local_command_landscape_integration.py`) and left the generator unchanged by Black. (succeeded). 
- Ran the integration test with `venv/bin/python -m unittest itests.test_local_command_landscape_integration` and it passed (`OK`). 
- Ran the generator standalone with `venv/bin/python itests/generate_landscape.py --lat 48.8566 --lon 2.3522 --time-file <timefile>` and verified it produced a `320x180` JPEG image (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699392487804832c8a72fb522baaab4f)